### PR TITLE
Add my signature

### DIFF
--- a/_posts/2022-03-08-proposed-cppcon_safety__letter_of_support.md
+++ b/_posts/2022-03-08-proposed-cppcon_safety__letter_of_support.md
@@ -298,6 +298,7 @@ Raoul Borges <br>
 Michael Allar <br>
 Shaun Anthony Roe <br>
 Oliver Rosten <br>
+Konrad Rudolph <br>
 
 Ways to sign this letter:
 1. A PR on the repo - path to file: [_posts/2022-03-08-proposed-cppcon_safety__letter_of_support.md][4]


### PR DESCRIPTION
I have never attended CppCon, nor am I formally a member of \#include \<C++\> but I’m a daily user of C++ and a somewhat prominent member of the C++ online community through my participation in the [`c++` tag](https://stackoverflow.com/help/badges/49/c?userid=1968) on Stack Overflow, and I support this letter.