### PR TITLE
Add a missing line break

### DIFF
--- a/_posts/2022-03-08-proposed-cppcon_safety__letter_of_support.md
+++ b/_posts/2022-03-08-proposed-cppcon_safety__letter_of_support.md
@@ -39,7 +39,7 @@ Gašper Ažman <br>
 Hannes Harnisch <br>
 Bronek Kozicki <br>
 Christopher Di Bella <br>
-Ryan McDougall
+Ryan McDougall <br>
 Tamir Bahar <br>
 Luna Kirkby <br>
 Michael Dowden <br>


### PR DESCRIPTION
A name was missing a line-break, causing 2 names to appear on the same line instead of separately.